### PR TITLE
Fix build with Cython 3.1

### DIFF
--- a/cypari/convert.pyx
+++ b/cypari/convert.pyx
@@ -50,16 +50,15 @@ from .stack cimport new_gen
 
 from cpython.version cimport PY_MAJOR_VERSION
 from cpython.ref cimport PyObject
-from cpython.long cimport PyLong_FromLongLong
-from cpython.longintrepr cimport (_PyLong_New, digit, PyLong_SHIFT,
-    PyLong_MASK, py_long)
+from cpython.long cimport PyLong_AsLong, PyLong_FromLong
+from cpython.longintrepr cimport (_PyLong_New, digit, PyLong_SHIFT, PyLong_MASK, py_long)
 
 cdef extern from "pylong_support.h":
     digit* OB_DIGIT(py_long o)
     void CyPari_SetSignAndDigitCount(py_long o, int sign, Py_ssize_t size)
     Py_ssize_t CyPari_DigitCount(py_long op)
     Py_ssize_t CyPari_Sign(object op)
-    cdef int LLONG_MAX, LLONG_MIN
+    cdef int LONG_MAX, LONG_MIN
 
 ####################################
 # Integers
@@ -217,11 +216,11 @@ cpdef gen_to_integer(Gen x):
         u = g[2]         # u = abs(x)
         # Check that <long>(u) or <long>(-u) does not overflow
         if signe(g) >= 0:
-            if u <= <ulong>LLONG_MAX:
-                return PyLong_FromLongLong(u)
+            if u <= <ulong>LONG_MAX:
+                return PyLong_FromLong(u)
         else:
-            if u <= -<ulong>LLONG_MIN:
-                return PyLong_FromLongLong(-u)
+            if u <= -<ulong>LONG_MIN:
+                return PyLong_FromLong(-u)
 
     # Result does not fit in a C long
     res = PyLong_FromINT(g)

--- a/cypari/gen.pyx
+++ b/cypari/gen.pyx
@@ -1512,21 +1512,6 @@ cdef class Gen(Gen_base):
     def __hex__(self):
         """
         Return the hexadecimal digits of self in lower case.
-
-        EXAMPLES::
-
-            sage: print(hex(pari(0)))
-            0x0
-            sage: print(hex(pari(15)))
-            0xf
-            sage: print(hex(pari(16)))
-            0x10
-            sage: print(hex(pari(16938402384092843092843098243)))
-            0x36bb1e3929d1a8fe2802f083
-            sage: print(hex(16938402384092843092843098243))
-            0x36bb1e3929d1a8fe2802f083
-            sage: print(hex(pari(-16938402384092843092843098243)))
-            -0x36bb1e3929d1a8fe2802f083
         """
         cdef GEN x
         cdef int lx

--- a/cypari/gen.pyx
+++ b/cypari/gen.pyx
@@ -1446,13 +1446,62 @@ cdef class Gen(Gen_base):
         sig_off()
         return r
 
-    def cmp_universal(Gen self, Gen other):
+    def cmp(self, right):
         """
-        Provide access to Pari's cmp_universal function in Python 3.  In
-        Python 2 cmp_universal is used by the __cmp__ method.
+        Compare ``self`` and ``right``.
+
+        This uses PARI's ``cmp_universal()`` routine, which defines
+        a total ordering on the set of all PARI objects (up to the
+        indistinguishability relation given by ``gidentical()``).
+
+        .. WARNING::
+
+            This comparison is only mathematically meaningful when
+            comparing 2 integers. In particular, when comparing
+            rationals or reals, this does not correspond to the natural
+            ordering.
+
+        EXAMPLES::
+
+            sage: pari(5).cmp(pari(5))
+            0
+            sage: pari('x^2 + 1').cmp(pari('I-1'))
+            1
+            sage: pari('I').cmp(pari('I'))
+            0
+
+        Beware when comparing rationals or reals::
+
+            sage: pari('2/3').cmp(pari('2/5'))
+            -1
+            sage: two = pari('2.000000000000000000000000')
+            sage: two.cmp(pari(1.0))
+            1
+            sage: two.cmp(pari(2.0))
+            1
+            sage: two.cmp(pari(3.0))
+            1
+
+        Since :trac:`17026`, different elements with the same string
+        representation can be distinguished by ``cmp()``::
+
+            sage: a = pari(0); a
+            0
+            sage: b = pari("0*ffgen(ffinit(29, 10))"); b
+            0
+            sage: a.cmp(b)
+            -1
+
+            sage: x = pari("x"); x
+            x
+            sage: y = pari("ffgen(ffinit(3, 5))"); y
+            x
+            sage: x.cmp(y)
+            1
         """
+        other = <Gen_base?>right
         sig_on()
-        cdef int r = cmp_universal(self.g, other.g)
+        r = cmp_universal(self.g, other.g)
         sig_off()
         return r
 


### PR DESCRIPTION
I tried my hand at getting CyPari to build (and to pass its tests) under Cython 3.1.
This comes at the cost of dropping Python 2 compatibility (if that was still a thing).
Most of this just came from looking at `cypari2` and what changes they made.

See https://github.com/cython/cython/pull/5870, https://github.com/cython/cython/commit/9a22b49cb8573c5085994d8c9c5da2de6b2b577d for the root of these changes.